### PR TITLE
Update parameter updates current ncov-tools packages with pangolin

### DIFF
--- a/conda_envs/ncov-qc-pangolin3.yaml
+++ b/conda_envs/ncov-qc-pangolin3.yaml
@@ -37,4 +37,5 @@ dependencies:
       - git+https://github.com/cov-lineages/pangoLEARN.git
       - git+https://github.com/cov-lineages/constellations.git
       - git+https://github.com/cov-lineages/scorpio.git
+      - git+https://github.com/cov-lineages/pango-designation.git
       - git+https://github.com/jts/ncov-watch.git

--- a/nml_automation/run_ncov-tools.sh
+++ b/nml_automation/run_ncov-tools.sh
@@ -15,7 +15,6 @@ eval "$(conda shell.bash hook)"
 # Default name is ncov-qc from https://github.com/jts/ncov-tools/blob/master/workflow/envs/environment.yml
 # May have to switch to a container or something similar later to make it easier
 conda activate $NCOV_ENV
-pip install ncov-parser --upgrade
 
 # If we have a matching negative control, we modify the config to make sure its gotten
 # If we don't find any, then no negative controls are added
@@ -42,7 +41,6 @@ $BASE_SCRIPTPATH/scripts/prename "s/_viral_reference././" *.sorted.bam
 cd ../
 snakemake -s workflow/Snakefile --cores 1 build_snpeff_db
 snakemake -s workflow/Snakefile all --cores $CORES
-snakemake -s workflow/Snakefile --cores 2 all_qc_annotation
 
 if [ "$PDF" = true ]; then
     snakemake -s workflow/Snakefile all_final_report --cores 1

--- a/run_signal.sh
+++ b/run_signal.sh
@@ -68,7 +68,7 @@ Flags:
                           only occur once and you won't have to pass the path each time
 
     OTHER:
-    --update  :  Passing --update will update pangolin and pangoLearn along with this repo and then exit
+    --update  :  Passing --update will update ncov-tools pip dependencies, pangolin and pangoLEARN along with this repo and then exit
 "
 ### END DEFAULTS ###
 
@@ -127,11 +127,18 @@ do
         shift
     elif [ "$1" = "--update" ]; then
         shift
+        # Scripts
         cd $SCRIPTPATH
         git pull
+
+        # ncov-tools Environment (not managed by snakemake unfortunately)
         eval "$(conda shell.bash hook)"
+        printf "\n Updating ncov-tools environment at $BASE_ENV_PATH/$NCOV_ENV \n\n"
         conda activate $BASE_ENV_PATH/$NCOV_ENV
+        pip install git+https://github.com/cov-lineages/pango-designation.git --upgrade
         pangolin --update
+        pip install ncov-parser --upgrade
+        pip install git+https://github.com/jts/ncov-watch.git --upgrade
         exit
     else
         shift


### PR DESCRIPTION
Basically just adding in the new pangolin dependency with the `run_signal.sh --update` parameter to make it easier to update along with adding pip installs for the ncov-tools tools that update somewhat frequently