### PR TITLE
Lineage Fix, Less restrictive metadata

### DIFF
--- a/nml_automation/negative_control_fixes.py
+++ b/nml_automation/negative_control_fixes.py
@@ -33,7 +33,7 @@ def main():
     args = parser.parse_args()
 
     # Read in qc csv file
-    df = pd.read_csv(args.qc_csv, sep=',')
+    df = pd.read_csv(args.qc_csv, sep=',', dtype=object)
 
     # Set the negative control headers which are static based on ncov-tools
     negative_columns = ['negative_control_qc', 'negative_control_genome_covered_bases', 'negative_control_genome_total_bases', 'negative_control_genome_covered_fraction', 'negative_control_amplicons_detected']
@@ -61,7 +61,6 @@ def main():
         df[key] = '-'.join(replace_dict[key])
 
     # Drop uneeded run name column and fill in blank columns
-    df.drop(['run_name'], axis=1, inplace=True)
     df.fillna('NA', inplace=True)
     df.to_csv('{}.qc.csv'.format(args.output_prefix), index=False)
 

--- a/run_signal.sh
+++ b/run_signal.sh
@@ -58,7 +58,7 @@ Flags:
     OPTIONAL:
     -c  --cores           :  Number of Cores to use in Signal. Default is 3
     -n  --run-name        :  Run name for final ncov-tools outputs. Default is 'nml'
-    -m  --metadata        :  Add metadata to the run. Must be in TSV format with the columns 'sample', 'date', and 'ct'
+    -m  --metadata        :  Add metadata to the run. Must be in TSV format with atleast a column called 'sample'
     --pdf                 :  If you have pdflatex installed runs ncov-tools pdf output
     --signal-env          :  Name of signal conda env. Default is '$BASE_ENV_PATH/signal'
     --ncov-tools-env      :  Name of ncov-tools env. Default is '$BASE_ENV_PATH/ncov-qc-pangolin3'
@@ -296,6 +296,13 @@ if [ $METADATA_TSV = 0 ]; then
     sed -i -e 's/^metadata/#metadata/' ./ncov-tools/config.yaml
     cleanup_metadata=""
 else
+    # Check if metadata has correct ncov-tools columns, if not we only append it to final output csv
+    if $(head -n 1 $FULL_PATH_METADATA | grep -q ct) && $(head -n 1 $FULL_PATH_METADATA | grep -q date); then
+        echo "Metadata contains correct ncov-tools headers"
+    else
+        echo "Metadata is missing ncov-tools headers, appending it only to final QC output"
+        sed -i -e 's/^metadata/#metadata/' ./ncov-tools/config.yaml
+    fi
     cp $FULL_PATH_METADATA ./ncov-tools/metadata.tsv
     cleanup_metadata="--sample_sheet $FULL_PATH_METADATA"
 fi


### PR DESCRIPTION
## Changes
- Allow the user to apply any metadata TSV file as long as it has a column called 'sample'
    - Still needs the 'ct' and 'date' columns to get it to work with ncov-tools but otherwise it adds all data to the final output

## Fixes
- Fix to lineages not populating final qc
- Fix to negative control script to make sure that data type populates correctly